### PR TITLE
Fixed Network Type issue

### DIFF
--- a/WapTenantPublicAPI.psm1
+++ b/WapTenantPublicAPI.psm1
@@ -1757,7 +1757,9 @@ function New-WAPVMRoleParameterObject {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value 'domain\username:password' -Force
             } elseif ($P.Type -eq 'Network') {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $($VMNetwork.Name) -Force
-            } elseif ($P.DefaultValue) {
+            } elseif ($P.Name -eq 'VMRoleNetworkRef') {
+                Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $($VMNetwork.Name) -Force
+            }elseif ($P.DefaultValue) {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $P.DefaultValue -Force
             } elseif ($Interactive) {
                 $result = Read-Host -Prompt "Enter a value for $($P.Name) of type $($P.Type)"

--- a/WapTenantPublicAPI.psm1
+++ b/WapTenantPublicAPI.psm1
@@ -1759,7 +1759,7 @@ function New-WAPVMRoleParameterObject {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $($VMNetwork.Name) -Force
             } elseif ($P.Name -eq 'VMRoleNetworkRef') {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $($VMNetwork.Name) -Force
-            }elseif ($P.DefaultValue) {
+            } elseif ($P.DefaultValue) {
                 Add-Member -InputObject $Output -MemberType NoteProperty -Name $P.Name -Value $P.DefaultValue -Force
             } elseif ($Interactive) {
                 $result = Read-Host -Prompt "Enter a value for $($P.Name) of type $($P.Type)"


### PR DESCRIPTION
VMNetwork objects are being passed as "Option" type rather than "Network" Type. 
Therefore the matching failed and the default network was always being used.  
Matching on the name instead - which fixes the workflow.

Unsure if this is an implementation specific issue or not. 