### PR TITLE
Disk Functions Added

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM | Connect-WAPVMRDP
 #connect to specific VM Role VM instance over RDP
 C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM -Name SRV001 | Connect-WAPVMRDP
 ```
+Disk Functions
+Get-WAPVMRoleVMDisk : Fetches all Disks currently attached to a WAPVMRoleVM. Returns WAP.DISK objects
+Expand-WAPVMRoleVMDisk: Takes a WAP.DISK Object a size in GB, expands the disk to the requested size.
+Invoke-WAPVMRoleVMDiskExpansion: Takes a WAP.DISK Object a size in GB. This stops the VM, Invokes the epansion command and then restarts the VM.
+
+Get-WAPVMRoleDisk: Fetches all Disks in the subscription. Returns WAP.DISKIMAGE Objects
+New-WAPVMRoleVMDisk: Takes a WAP.DISKIMAGE object and a Cloud Service Name, then mounts attaches the Disk to the VM.

--- a/README.md
+++ b/README.md
@@ -130,11 +130,17 @@ C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM | Connect-WAPVMRDP
 
 #connect to specific VM Role VM instance over RDP
 C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM -Name SRV001 | Connect-WAPVMRDP
-```
-Disk Functions
-Get-WAPVMRoleVMDisk : Fetches all Disks currently attached to a WAPVMRoleVM. Returns WAP.DISK objects
-Expand-WAPVMRoleVMDisk: Takes a WAP.DISK Object a size in GB, expands the disk to the requested size.
-Invoke-WAPVMRoleVMDiskExpansion: Takes a WAP.DISK Object a size in GB. This stops the VM, Invokes the epansion command and then restarts the VM.
 
-Get-WAPVMRoleDisk: Fetches all Disks in the subscription. Returns WAP.DISKIMAGE Objects
-New-WAPVMRoleVMDisk: Takes a WAP.DISKIMAGE object and a Cloud Service Name, then mounts attaches the Disk to the VM.
+##Disk Functions
+#Get-WAPVMRoleVMDisk
+Fetches all Disks currently attached to a WAPVMRoleVM. Returns WAP.DISK objects
+#Expand-WAPVMRoleVMDisk
+Takes a WAP.DISK Object a size in GB, expands the disk to the requested size.
+#Invoke-WAPVMRoleVMDiskExpansion
+Takes a WAP.DISK Object a size in GB. This stops the VM, Invokes the epansion command and then restarts the VM.
+
+#Get-WAPVMRoleDisk
+Fetches all Disks in the subscription. Returns WAP.DISKIMAGE Objects
+#New-WAPVMRoleVMDisk 
+Takes a WAP.DISKIMAGE object and a Cloud Service Name, then mounts attaches the Disk to the VM.
+```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM | Connect-WAPVMRDP
 #connect to specific VM Role VM instance over RDP
 C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM -Name SRV001 | Connect-WAPVMRDP
 
-##Disk Functions
+#Disk Functions
 #Get-WAPVMRoleVMDisk
 Fetches all Disks currently attached to a WAPVMRoleVM. Returns WAP.DISK objects
 #Expand-WAPVMRoleVMDisk

--- a/WapTenantPublicAPI.psm1
+++ b/WapTenantPublicAPI.psm1
@@ -4056,7 +4056,7 @@ Param(
     $Size
 )
     Begin{
-        if (!($Disk.pstypenames.Contains('WAP.DISKIMAGE'))) {
+        if (!($Disk.pstypenames.Contains('WAP.DISK'))) {
             throw 'Object bound to Disk parameter is of the wrong type'
         }
     }


### PR DESCRIPTION
Get-WAPVMRoleVMDisk : Fetches all Disks currently attached to a WAPVMRoleVM. Returns WAP.DISK objects
Expand-WAPVMRoleVMDisk: Takes a WAP.DISK Object a size in GB, expands the disk to the requested size.
Invoke-WAPVMRoleVMDiskExpansion: Takes a WAP.DISK Object a size in GB. This stops the VM, Invokes the epansion command and then restarts the VM. 

Get-WAPVMRoleDisk: Fetches all Disks in the subscription. Returns WAP.DISKIMAGE Objects
New-WAPVMRoleVMDisk: Takes a WAP.DISKIMAGE object and a Cloud Service Name, then mounts attaches the Disk to the VM. 