### PR TITLE
Added Quota functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM
 #get additional information for VM Role deployed VM instance
 Get-WAPCloudService -Name DCs | Get-WAPVMroleVM -VMMEnhanced
 
+#get quotas of your subscriptions
+Get-WAPSubscriptionQuota 
+
+#Confirm whether a specific request will meet a quota. 
+Get-WAPSubscription -Name "MySubscription" | Get-WAPVMRoleQuotaRequest -Size "Large" -NumberOfNodes 4
+
 #connect to VM Role VM instances over RDP
 C:\>Get-WAPCloudService -Name DCs | Get-WAPVMRoleVM | Connect-WAPVMRDP
 


### PR DESCRIPTION
Needed to be able to determine whether or not an API call would succeed due to quotas. 

Get-WAPSubscriptionQuota pulls the quota and returns an object with nulls. Give it a Subscription - if there isn't one, it'll get the quota objects for all of them. You can use this for reporting purposes too. 

Get-WAPVMRoleQuotaRequest takes a Subscription and VMRoleSizeProfile (or a name of one). It checks to see if the amount of those Node sizes will break the bank. Utilmately the WithinQuota boolean is what you need. 

I've tested it and it all works, can you just do a quick code review to confirm you're happy @bgelens :)